### PR TITLE
fixed test.sh instance name bug

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,32 +1,32 @@
-MASTER_IP=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' rediscluster_master_1)
-SLAVE_IP=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' rediscluster_slave_1)
-SENTINEL_IP=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' rediscluster_sentinel_1)
+MASTER_IP=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' redis-cluster_master_1)
+SLAVE_IP=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' redis-cluster_slave_1)
+SENTINEL_IP=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' redis-cluster_sentinel_1)
 
 echo Redis master: $MASTER_IP
 echo Redis Slave: $SLAVE_IP
 echo ------------------------------------------------
 echo Initial status of sentinel
 echo ------------------------------------------------
-docker exec rediscluster_sentinel_1 redis-cli -p 26379 info Sentinel
+docker exec redis-cluster_sentinel_1 redis-cli -p 26379 info Sentinel
 echo Current master is
-docker exec rediscluster_sentinel_1 redis-cli -p 26379 SENTINEL get-master-addr-by-name mymaster
+docker exec redis-cluster_sentinel_1 redis-cli -p 26379 SENTINEL get-master-addr-by-name mymaster
 echo ------------------------------------------------
 
 echo Stop redis master
-docker pause rediscluster_master_1
+docker pause redis-cluster_master_1
 echo Wait for 10 seconds
 sleep 10
 echo Current infomation of sentinel
-docker exec rediscluster_sentinel_1 redis-cli -p 26379 info Sentinel
+docker exec redis-cluster_sentinel_1 redis-cli -p 26379 info Sentinel
 echo Current master is
-docker exec rediscluster_sentinel_1 redis-cli -p 26379 SENTINEL get-master-addr-by-name mymaster
+docker exec redis-cluster_sentinel_1 redis-cli -p 26379 SENTINEL get-master-addr-by-name mymaster
 
 
 echo ------------------------------------------------
 echo Restart Redis master
-docker unpause rediscluster_master_1
+docker unpause redis-cluster_master_1
 sleep 5
 echo Current infomation of sentinel
-docker exec rediscluster_sentinel_1 redis-cli -p 26379 info Sentinel
+docker exec redis-cluster_sentinel_1 redis-cli -p 26379 info Sentinel
 echo Current master is
-docker exec rediscluster_sentinel_1 redis-cli -p 26379 SENTINEL get-master-addr-by-name mymaster
+docker exec redis-cluster_sentinel_1 redis-cli -p 26379 SENTINEL get-master-addr-by-name mymaster


### PR DESCRIPTION
docker for mac  Version 18.03.1-ce-mac65 (24312)

docker-compose version 1.21.1, build 5a3f1a3
docker-py version: 3.3.0
CPython version: 3.6.4
OpenSSL version: OpenSSL 1.0.2o  27 Mar 2018
