### PR TITLE
Fix docker-compose.yml formatting to support docker-compose up --build

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,28 +20,28 @@ The template defines the topology of the Redis cluster:
 version: '3.9'
 
 services:
-master:
-image: redis:latest
-container_name: redis-master
+  master:
+    image: redis:latest
+    container_name: redis-master
 
-slave:
-image: redis:latest
-container_name: redis-slave
-command: redis-server --slaveof redis-master 6379
-depends_on:
-- master
+  slave:
+    image: redis:latest
+    container_name: redis-slave
+    command: redis-server --slaveof redis-master 6379
+    depends_on:
+    - master
 
-sentinel:
-build:
-context: ./sentinel
-dockerfile: Dockerfile
-container_name: redis-sentinel
-environment:
-- SENTINEL_DOWN_AFTER=5000
-- SENTINEL_FAILOVER=5000
-depends_on:
-- master
-- slave
+  sentinel:
+    build:
+      context: ./sentinel
+      dockerfile: Dockerfile
+    container_name: redis-sentinel
+    environment:
+      - SENTINEL_DOWN_AFTER=5000
+      - SENTINEL_FAILOVER=5000
+    depends_on:
+    - master
+    - slave
 ```
 
 Notes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,25 @@
 version: '3.9'
 
 services:
-master:
-image: redis:latest
-container_name: redis-master
+  master:
+    image: redis:latest
+    container_name: redis-master
 
-slave:
-image: redis:latest
-container_name: redis-slave
-command: redis-server --slaveof redis-master 6379
-depends_on:
-- master
+  slave:
+    image: redis:latest
+    container_name: redis-slave
+    command: redis-server --slaveof redis-master 6379
+    depends_on:
+    - master
 
-sentinel:
-build:
-context: ./sentinel
-dockerfile: Dockerfile
-container_name: redis-sentinel
-environment:
-- SENTINEL_DOWN_AFTER=5000
-- SENTINEL_FAILOVER=5000
-depends_on:
-- master
-- slave
+  sentinel:
+    build:
+      context: ./sentinel
+      dockerfile: Dockerfile
+    container_name: redis-sentinel
+    environment:
+      - SENTINEL_DOWN_AFTER=5000
+      - SENTINEL_FAILOVER=5000
+    depends_on:
+    - master
+    - slave


### PR DESCRIPTION
This PR addresses critical issue preventing successful deployment:

The following command was not working, because docker-compose.yml has some serious issues with formatting
```
docker-compose up -d --build
```

So docker-compose.yml was fixed to ensure correct formatting to make everything work 